### PR TITLE
Use version of natural module that doesn't depend on webworker-threads

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "typescript": "^2.4.2"
   },
   "dependencies": {
-    "natural": "^0.5.4",
+    "natural": "0.5.0",
     "xregexp": "^3.2.0"
   },
   "main": "lib/index.js",


### PR DESCRIPTION
As a temporary solution until #4 is implemented, this pull request updates spelling-manager to depend on the last version of the natural module that didn't include the webworker-threads dependency.

The webworker-threads dependency was introduced in https://github.com/NaturalNode/natural/commit/ba626e972eeec89b82e89e0bd2cbbabf97ead6d3, which first appears in [0.5.1](https://github.com/NaturalNode/natural/blame/ae15dd821d61b616bdc2c4b1af915e1a1b7f02a7/package.json#L4). Therefore, this pull request declares a strict dependency on [0.5.0](https://github.com/NaturalNode/natural/blob/378ec2b1511b8103ac483eb1a3a73ae6c335da3a/package.json#L4).

---

@dmoonfire: Would you be willing to merge this pull request and publish a new version of the spelling-manager module so that we can use it to resolve the issue described in https://github.com/atom/spell-check/issues/67#issuecomment-377808833?